### PR TITLE
No longer combine styles, create separate elements instead

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function appendStyles(options) {
     throw new Error('You need to specify the id of the style element');
   }
 
-  var styleElement = document.getElementById(id) || createStyleElement(options);
+  var styleElement = createStyleElement(options);
 
   // strip potential UTF-8 BOM if css was read from a file
   if (css.charCodeAt(0) === 0xfeff) {
@@ -29,15 +29,17 @@ function appendStyles(options) {
 function createStyleElement(options) {
   var styleElement = document.createElement('style');
   styleElement.setAttribute('type', 'text/css');
-  styleElement.setAttribute('id', options.id);
+  styleElement.setAttribute('data-append-styles', options.id);
 
   var head = document.head
 
   var target = head.childNodes[0];
-  var before = options.before && document.getElementById(options.before);
-  var after = options.after && document.getElementById(options.after);
+  var before = options.before && document.querySelectorAll('[data-append-styles="' + options.before + '"]');
+  var after = options.after && document.querySelectorAll('[data-append-styles="' + options.after + '"]');
+  var startElement = before && before[0];
+  var endElement = after && after[after.length - 1];
 
-  target = before || (after && after.nextSibling) || target;
+  target = startElement || (endElement && endElement.nextSibling) || target;
 
   head.insertBefore(styleElement, target);
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -23,7 +23,7 @@ describe('append-styles', function() {
     });
 
     expect(document, 'to contain styles', [
-      '<style id="module-b">body { background:red; }</style>'
+      '<style data-append-styles="module-b">body { background:red; }</style>'
     ]);
 
     appendStyles({
@@ -33,8 +33,8 @@ describe('append-styles', function() {
     });
 
     expect(document, 'to contain styles', [
-      '<style id="module-a">body { background:blue; }</style>',
-      '<style id="module-b">body { background:red; }</style>'
+      '<style data-append-styles="module-a">body { background:blue; }</style>',
+      '<style data-append-styles="module-b">body { background:red; }</style>'
     ]);
 
     appendStyles({
@@ -44,8 +44,9 @@ describe('append-styles', function() {
     });
 
     expect(document, 'to contain styles', [
-      '<style id="module-a">body { background:blue; }h1 { color:papayawhip; }</style>',
-      '<style id="module-b">body { background:red; }</style>'
+      '<style data-append-styles="module-a">body { background:blue; }</style>',
+      '<style data-append-styles="module-a">h1 { color:papayawhip; }</style>',
+      '<style data-append-styles="module-b">body { background:red; }</style>'
     ]);
 
     appendStyles({
@@ -55,63 +56,10 @@ describe('append-styles', function() {
     });
 
     expect(document, 'to contain styles', [
-      '<style id="module-a">body { background:blue; }h1 { color:papayawhip; }</style>',
-      '<style id="module-b">body { background:red; }h1 { color:black; }</style>'
+      '<style data-append-styles="module-a">body { background:blue; }</style>',
+      '<style data-append-styles="module-a">h1 { color:papayawhip; }</style>',
+      '<style data-append-styles="module-b">h1 { color:black; }</style>',
+      '<style data-append-styles="module-b">body { background:red; }</style>'
     ]);
   });
-
-  describe('when the DOM already contains style tags with the same id', () => {
-    beforeEach(() => {
-      document.head.innerHTML = [
-        '<style id="module-a">body { background:yellow; }p { color:gray; }</style>',
-        '<style id="module-b">body { background:green; }p { color:white; }</style>'
-      ].join('')
-    })
-
-    it('appends to the existing style tag', () => {
-      appendStyles({
-        css: 'body { background:red; }',
-        id: 'module-b',
-        after: 'module-a'
-      });
-
-      expect(document, 'to contain styles', [
-        '<style id="module-a">body { background:yellow; }p { color:gray; }</style>',
-        '<style id="module-b">body { background:green; }p { color:white; }body { background:red; }</style>'
-      ]);
-
-      appendStyles({
-        css: 'body { background:blue; }',
-        id: 'module-a',
-        before: 'module-b'
-      });
-
-      expect(document, 'to contain styles', [
-        '<style id="module-a">body { background:yellow; }p { color:gray; }body { background:blue; }</style>',
-        '<style id="module-b">body { background:green; }p { color:white; }body { background:red; }</style>'
-      ]);
-
-      appendStyles({
-        css: 'h1 { color:papayawhip; }',
-        id: 'module-a',
-        before: 'module-b'
-      });
-
-      expect(document, 'to contain styles', [
-        '<style id="module-a">body { background:yellow; }p { color:gray; }body { background:blue; }h1 { color:papayawhip; }</style>',
-        '<style id="module-b">body { background:green; }p { color:white; }body { background:red; }</style>'
-      ]);
-
-      appendStyles({
-        css: 'h1 { color:black; }',
-        id: 'module-b',
-        after: 'module-a'
-      });
-
-      expect(document, 'to contain styles', [
-        '<style id="module-a">body { background:yellow; }p { color:gray; }body { background:blue; }h1 { color:papayawhip; }</style>',
-        '<style id="module-b">body { background:green; }p { color:white; }body { background:red; }h1 { color:black; }</style>'
-      ]);
-    })
-  })
 });


### PR DESCRIPTION
Appending additional styles to the existing element is not very performant when the content of the element grows. Especially on IE.

This PR stops appending to the existing `style` element and instead creates a new, keeping the order correct.

It also stops using the `id` attribute, since with the new approach there would multiple elements with the same `id` which isn't semantically correct. Uses `data-append-styles` attributes instead.