### PR TITLE
Support webpack nonce

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,10 @@ function createStyleElement(options) {
   styleElement.setAttribute('type', 'text/css');
   styleElement.setAttribute('data-append-styles', id);
 
+  if (__webpack_nonce__) {
+    styleElement.nonce = __webpack_nonce__;
+  }
+
   var head = document.head
 
   var target = head.childNodes[0];


### PR DESCRIPTION
This is required to allow inline styles when using CSP, and it is a common approach in CSS-in-JS.

- https://webpack.js.org/guides/csp/#examples
- https://github.com/styled-components/styled-components/pull/2483/files